### PR TITLE
IssueID #20539 + #20540 - Add functionality for dealing with large em…

### DIFF
--- a/dspace/modules/additions/src/main/java/uk/ac/edina/datashare/ctask/general/EmailableBitstreamsChecker.java
+++ b/dspace/modules/additions/src/main/java/uk/ac/edina/datashare/ctask/general/EmailableBitstreamsChecker.java
@@ -1,0 +1,173 @@
+package uk.ac.edina.datashare.ctask.general;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.curate.AbstractCurationTask;
+import org.dspace.curate.Curator;
+import org.dspace.curate.Distributive;
+
+/**
+ * A curation job to check if an item's bitstreams are too large to be emailed together 
+ * and which of the item's bitstreams cannot be emailed separately because of size.
+ * 
+ * @author John Pinto
+ *
+ */
+
+@Distributive
+public class EmailableBitstreamsChecker extends AbstractCurationTask {
+
+	private static Logger log = Logger.getLogger(EmailableBitstreamsChecker.class);
+
+	
+	private static final String EMAILABLE_BITSTREAMS_MAX_SIZE_IN_MB_KEY = "emailable.bitstreams.max.size";
+	private static final int DEFAULT_EMAILABLE_BITSTREAMS_MAX_SIZE_IN_MB = 100;
+	private static final long ONE_MEGABYTE_SIZE_IN_BYTES = 1024L * 1024L;
+
+	private static final String DS_METADATA_SCHEMA = "ds";
+	private static final String NOT_EMAILABLE_METADATA_ELEMENT = "not-emailable";
+	private static final String BITSTREAM_METADATA_QUALIFIER = "bitstream";
+	private static final String ITEM_METADATA_QUALIFIER = "item";
+	private static final String METADATA_LANGUAGE = "en";
+	private static final String TRUE = "true";
+
+	private int status = Curator.CURATE_UNSET;
+	private long maxAllowedBitstreamsSizeInBytes;
+	
+	private long totalBitstreamSize = 0L;
+
+	@Override
+	public void init(Curator curator, String taskId) throws IOException {
+		super.init(curator, taskId);
+		maxAllowedBitstreamsSizeInBytes = 
+				ConfigurationManager.getLongProperty(EMAILABLE_BITSTREAMS_MAX_SIZE_IN_MB_KEY,
+						DEFAULT_EMAILABLE_BITSTREAMS_MAX_SIZE_IN_MB) * ONE_MEGABYTE_SIZE_IN_BYTES;
+	}
+
+	/**
+	 * Add metadata for non-emailable bitreams and the corresponding item.
+	 *
+	 * @param dso
+	 *            The DSpaceObject to be checked
+	 * @return The curation task status of the checking
+	 */
+	@Override
+	public int perform(DSpaceObject dso) {
+		// The results that we'll return
+		StringBuilder results = new StringBuilder();
+
+		// Unless this is an item, we'll skip this item
+		status = Curator.CURATE_SKIP;
+		logDebugMessage("The target dso is " + dso.getName());
+		if (dso instanceof Item) {
+			boolean itemNotEmailableMetadataSet = false;
+			try {
+				Item item = (Item) dso;
+				item.clearMetadata(DS_METADATA_SCHEMA,
+						           NOT_EMAILABLE_METADATA_ELEMENT,
+						           ITEM_METADATA_QUALIFIER,
+						           METADATA_LANGUAGE);
+				for (Bundle bundle : item.getBundles()) {
+
+					if ("ORIGINAL".equals(bundle.getName())) {
+						for (Bitstream bitstream : bundle.getBitstreams()) {
+							totalBitstreamSize += bitstream.getSize();
+							logDebugMessage("The bitstream size (bytes): " + bitstream.getSize());
+							if (bitstream.getSize() > maxAllowedBitstreamsSizeInBytes) {
+								addItemMetaData(item, itemNotEmailableMetadataSet);
+								itemNotEmailableMetadataSet = true;
+								addBitstreamMetaData(bitstream);
+								bitstream.update();
+								
+							}
+						}
+					} else if ("THUMBNAIL".equals(bundle.getName())) {
+						for (Bitstream bitstream : bundle.getBitstreams()) {
+							totalBitstreamSize += bitstream.getSize();
+							logDebugMessage("The bitstream size (bytes): " + bitstream.getSize());
+							if (bitstream.getSize() > maxAllowedBitstreamsSizeInBytes) {
+								addItemMetaData(item, itemNotEmailableMetadataSet);
+								itemNotEmailableMetadataSet = true;
+								addBitstreamMetaData(bitstream);
+								bitstream.update();
+							}
+						}
+					}
+				}
+				
+				logDebugMessage("The total item's bitstreams size (bytes): " + totalBitstreamSize);
+				// If the total size of the bitstreams exceeds the max-size then update the item metadata.
+				if (totalBitstreamSize > maxAllowedBitstreamsSizeInBytes) {
+					addItemMetaData(item, itemNotEmailableMetadataSet);
+					itemNotEmailableMetadataSet = true;
+				}
+				item.update();
+                status = Curator.CURATE_SUCCESS;
+
+			} catch (AuthorizeException ae) {
+				// Something went wrong
+				logDebugMessage(ae.getMessage());
+				status = Curator.CURATE_ERROR;
+			} catch (SQLException sqle) {
+				// Something went wrong
+				logDebugMessage(sqle.getMessage());
+				status = Curator.CURATE_ERROR;
+			}
+
+		}
+
+		logDebugMessage("About to report: " + results.toString());
+		setResult(results.toString());
+		report(results.toString());
+
+		return status;
+	}
+
+	// Add metadata to item object for a non-emailable item's bitstreamms because of total size.
+	private void addItemMetaData(Item item, boolean alreadySet) {
+		// Only update if not already set.
+		if (alreadySet) {
+			item.addMetadata(DS_METADATA_SCHEMA,
+					         NOT_EMAILABLE_METADATA_ELEMENT,
+					         ITEM_METADATA_QUALIFIER,
+					         METADATA_LANGUAGE,
+					         TRUE);
+		}
+	}
+	
+	// Add metadata to the bitstream object if it is non-emailable.
+	private void addBitstreamMetaData(Bitstream bitstream) {
+		// Clear metadata field we plan to update
+		bitstream.clearMetadata(DS_METADATA_SCHEMA,
+                                NOT_EMAILABLE_METADATA_ELEMENT,
+                                BITSTREAM_METADATA_QUALIFIER,
+                                METADATA_LANGUAGE);
+		// Add metadata
+		bitstream.addMetadata(DS_METADATA_SCHEMA,
+					          NOT_EMAILABLE_METADATA_ELEMENT,
+					          BITSTREAM_METADATA_QUALIFIER,
+					          METADATA_LANGUAGE,
+					          TRUE);
+	}
+
+	/**
+	 * Debugging logging if required
+	 *
+	 * @param message
+	 *            The message to log
+	 */
+	private void logDebugMessage(String message) {
+		if (log.isDebugEnabled()) {
+			log.debug(message);
+		}
+	}
+
+}

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendItemRequestAction.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/SendItemRequestAction.java
@@ -1,0 +1,213 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.xmlui.aspect.artifactbrowser;
+
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.avalon.framework.parameters.Parameters;
+import org.apache.cocoon.acting.AbstractAction;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.environment.Redirector;
+import org.apache.cocoon.environment.Request;
+import org.apache.cocoon.environment.SourceResolver;
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Logger;
+import org.dspace.app.requestitem.RequestItem;
+import org.dspace.app.requestitem.RequestItemAuthor;
+import org.dspace.app.requestitem.RequestItemAuthorExtractor;
+import org.dspace.app.xmlui.utils.ContextUtil;
+import org.dspace.app.xmlui.utils.HandleUtil;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Metadatum;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Context;
+import org.dspace.core.Email;
+import org.dspace.core.I18nUtil;
+import org.dspace.core.Utils;
+import org.dspace.eperson.EPerson;
+import org.dspace.handle.HandleManager;
+import org.dspace.storage.rdbms.DatabaseManager;
+import org.dspace.storage.rdbms.TableRow;
+import org.dspace.utils.DSpace;
+
+ /**
+ * This action will send a mail to request a item to administrator when all mandatory data is present.
+ * It will record the request into the database.
+ * 
+ * Original Concept, JSPUI version:    Universidade do Minho   at www.uminho.pt
+ * Sponsorship of XMLUI version:    Instituto Oceanográfico de España at www.ieo.es
+ * 
+ * @author Adán Román Ruiz at arvo.es (added request item support)
+ */
+public class SendItemRequestAction extends AbstractAction
+{
+    private static Logger log = Logger.getLogger(SendItemRequestAction.class);
+    
+    // DATASHARE - start
+    private static final String ITEM_NOT_EMAILABLE_METADATA_TAG = "ds.not-emailable.item";
+    private static final String BITSTREAM_NOT_EMAILABLE_METADATA_TAG = "ds.not-emailable.bitstream";
+    
+    // DATASHARE - end
+
+    public Map act(Redirector redirector, SourceResolver resolver, Map objectModel,
+            String source, Parameters parameters) throws Exception
+    {
+        Request request = ObjectModelHelper.getRequest(objectModel);
+       
+        String requesterName = request.getParameter("requesterName");
+        String requesterEmail = request.getParameter("requesterEmail");
+        String allFiles = request.getParameter("allFiles");
+        String message = request.getParameter("message");
+        String bitstreamId = request.getParameter("bitstreamId");
+     
+        // User email from context
+        Context context = ContextUtil.obtainContext(objectModel);
+        EPerson loggedin = context.getCurrentUser();
+        String eperson = null;
+        if (loggedin != null)
+        {
+            eperson = loggedin.getEmail();
+        }
+
+        // Check all data is there
+        if (StringUtils.isEmpty(requesterName) || StringUtils.isEmpty(requesterEmail) || StringUtils.isEmpty(allFiles) || StringUtils.isEmpty(message))
+        {
+            // Either the user did not fill out the form or this is the
+            // first time they are visiting the page.
+            Map<String,String> map = new HashMap<String,String>();
+            map.put("bitstreamId",bitstreamId);
+
+            if (StringUtils.isEmpty(requesterEmail))
+            {
+                map.put("requesterEmail", eperson);
+            }
+            else
+            {
+                map.put("requesterEmail", requesterEmail);
+            }
+            map.put("requesterName",requesterName);
+            map.put("allFiles",allFiles);
+            map.put("message",message);
+            return map;
+        }
+    	DSpaceObject dso = HandleUtil.obtainHandle(objectModel);
+        if (!(dso instanceof Item))
+        {
+            throw new Exception("Invalid DspaceObject at ItemRequest.");
+        }
+        
+        Item item = (Item) dso;
+        String title = "";
+        Metadatum[] titleDC = item.getDC("title", null, Item.ANY);
+        if (titleDC == null || titleDC.length == 0) {
+            titleDC = item.getDC("title", Item.ANY, Item.ANY); // dc.title with qualifier term
+        }
+        if (titleDC != null && titleDC.length > 0) {
+            title = titleDC[0].value;
+        }
+        
+        RequestItemAuthor requestItemAuthor = new DSpace()
+                .getServiceManager()
+                .getServiceByName(
+                        RequestItemAuthorExtractor.class.getName(),
+                        RequestItemAuthorExtractor.class
+                )
+                .getRequestItemAuthor(context, item);
+
+        RequestItem requestItem = new RequestItem(item.getID(), Integer.parseInt(bitstreamId), requesterEmail, requesterName, message, Boolean.getBoolean(allFiles));
+
+        // All data is there, send the email
+        
+        // DATASHARE - start
+        Email email;
+     	if (isRequestItemEmailable(context, requestItem, item)) {
+     		email = Email.getEmail(I18nUtil.getEmailFilename(context.getCurrentLocale(), "request_item.author"));
+     	} else {
+     		// Note: Email trplate request_item.not_emailable.author is in the GitLab dspace_env rep
+     		email = Email.getEmail(I18nUtil.getEmailFilename(context.getCurrentLocale(), "request_item.not_emailable.author"));
+     	}
+        // DATASHARE - end
+        
+        email.addRecipient(requestItemAuthor.getEmail());
+
+        email.addArgument(requesterName);    
+        email.addArgument(requesterEmail);   
+        email.addArgument(allFiles.equals("true")?I18nUtil.getMessage("itemRequest.all"):Bitstream.find(context,Integer.parseInt(bitstreamId)).getName());      
+        email.addArgument(HandleManager.getCanonicalForm(item.getHandle()));      
+        email.addArgument(title);    // request item title
+        email.addArgument(message);   // message
+        email.addArgument(getLinkTokenEmail(context,requestItem));
+        email.addArgument(requestItemAuthor.getFullName());    //   corresponding author name
+        email.addArgument(requestItemAuthor.getEmail());    //   corresponding author email
+        email.addArgument(ConfigurationManager.getProperty("dspace.name"));
+        email.addArgument(ConfigurationManager.getProperty("mail.helpdesk"));
+
+        email.setReplyTo(requesterEmail);
+         
+        email.send();
+        // Finished, allow to pass.
+        return null;
+    }
+
+    /**
+     * Get the link to the author in RequestLink email.
+     * @param context
+     * @param requestItem
+     * @return
+     * @throws SQLException
+     */
+    protected String getLinkTokenEmail(Context context, RequestItem requestItem)
+            throws SQLException
+    {
+        String base = ConfigurationManager.getProperty("dspace.url");
+
+        String specialLink = (new StringBuffer()).append(base).append(
+                base.endsWith("/") ? "" : "/").append(
+                "itemRequestResponse/").append(requestItem.getNewToken(context))
+                .toString()+"/";
+
+        return specialLink;
+    }
+    
+    /**
+     * Checks if requested item is emailable.
+     * 
+     */
+    private boolean isRequestItemEmailable(Context context, RequestItem requestItem, Item item) {
+    	// Check if requested item is an Item or Bitstream and if it has the metadata tag:
+    	// ds.not-emailable.item for Item or
+    	// ds.not-emailable.bitstream for bitstream.
+    	try {
+    		if (requestItem.isAllfiles() && item.getMetadata(ITEM_NOT_EMAILABLE_METADATA_TAG) != null){
+    			log.debug(ITEM_NOT_EMAILABLE_METADATA_TAG + ": " + item.getMetadata(ITEM_NOT_EMAILABLE_METADATA_TAG));
+    			return false;
+    		} else {
+    			Bitstream bit = Bitstream.find(context, requestItem.getBitstreamId());
+    			if (bit != null && bit.getMetadata(BITSTREAM_NOT_EMAILABLE_METADATA_TAG) != null) {
+    				log.debug(BITSTREAM_NOT_EMAILABLE_METADATA_TAG + ": " + item.getMetadata(BITSTREAM_NOT_EMAILABLE_METADATA_TAG));
+    			 return false;
+    			}
+    		}
+    	 } catch (IllegalArgumentException iae) {
+    		// Do nothing as it means that the requested item does not have
+    		// either of the not emailable metadata tags:
+    		// ds.not-emailable.item or ds.not-emailable.bitstream
+    	} catch (SQLException sqle) {
+    		// Do nothing (should not happen) 
+    	}
+    	
+    	return true;
+    }
+    // DATASHARE - start
+
+}


### PR DESCRIPTION
…bargoed files requested by persons.

- Adding functionality for preventing a data author emailing embargoed item
    files if it is too large for email purposes.

    - Added SendItemRequestAction.java in the modules folder to send a different email to Author if the requested items or bitstram files are not emailable.
    - Added a test to ItemRequestResponseAction.java in the modules folder to check if a requested item bitstream/s can be emailed.

- Added a Curation Task for adding metadadata to items and bitstreams with size above a set threshold value (currently 100 MB).
  To work the following changes have been made to the dspace_env puppet repo.

     -dspace submodule:
        The property that holds the value is set in dspace.cfg.erb file
to get round this.)
           # Max bitstreams size (in MB) emailable
           emailable.bitstreams.max.size = 100

     -datashare submodule:
        The workflow-curation.xml has been updated and added.