### PR TITLE
Set the Log level to INFO for logging XML sent to DataCite.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/EZIDIdentifierProvider.java
@@ -610,7 +610,7 @@ public class EZIDIdentifierProvider
             DataCiteXMLCreator xmlGen = new DataCiteXMLCreator();
             xmlGen.setDisseminationCrosswalkName(DATACITE_XML_CROSSWALK);
             String xmlString = xmlGen.getXMLString(dso);
-            log.debug("Generated DataCite XML:  {}", xmlString);
+            log.info("Generated DataCite XML:  {}", xmlString);
             mapped.put("datacite", xmlString);
         }
 


### PR DESCRIPTION
We have changed the log level in EZIDIdentifierProvider for the generated XML string
from log.debug("Generated DataCite XML:  {}", xmlString) to
log.info("Generated DataCite XML:  {}", xmlString).