### PR TITLE
IssueID #21410 - Added functionality to enable Google Dataset Search …

### DIFF
--- a/dspace-xmlui/src/main/webapp/static/js/datacite_metadata_schema_org_request.js
+++ b/dspace-xmlui/src/main/webapp/static/js/datacite_metadata_schema_org_request.js
@@ -1,0 +1,47 @@
+// DATASHARE - start
+$(document).ready(function () {
+  try {
+    // This is a Datashare specific script. Other DSpace users will need to alter the script for their purpose.
+    // Look for meta tag like <meta name="DC.identifier" content="https://doi.org/10.7488/ds/2503" scheme="DCTERMS.URI" /> to get DOI
+    var doiDcIdentifierElement = $("meta[name='DC.identifier'][content^='https://doi.org/10.7488/ds']");
+
+    // Return if no DOI metadata  tag found
+    if (doiDcIdentifierElement.length != 1) {
+      return;
+    }
+
+    // URLs of live and test Datacite api
+    var LIVE_DATACITE_API_URL = "https://api.datacite.org/dois/application/vnd.schemaorg.ld+json";
+    var TEST_DATACITE_API_URL = "https://api.test.datacite.org/dois/application/vnd.schemaorg.ld+json";
+
+    var doiString = doiDcIdentifierElement.attr("content");
+    var doi = new URL(doiString);
+
+    // Url to get Datacite schema date to populate script used in Google Search
+    var url;
+
+    if (doiString.match(/^https:\/\/doi.org\/10.7488\/ds\//)) {
+      url = LIVE_DATACITE_API_URL + doi.pathname;
+    } else if (doiString.match(/^https:\/\/doi.org\/10.7488\/dsbeta\//)) {
+      url = TEST_DATACITE_API_URL + doi.pathname;
+    }
+
+    $.ajax({
+      url: url,
+      dataType: 'text', // don't convert JSON to Javascript object
+      success: function (data) {
+        $('<script>')
+          .attr('type', 'application/ld+json')
+          .text(data)
+          .appendTo('head');
+      },
+      error: function (error) {
+        console.log(error.responseJSON);
+      }
+    });
+  }
+  catch (e) {
+    console.log(e);
+  }
+});
+// DATASHARE - end

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
@@ -219,6 +219,10 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
             pageMeta.addMetadata("sfx","server").addContent(sfxserverUrl);
         }
         
+        // DATASHARE - start
+        pageMeta.addMetadata("javascript", "static").addContent("static/js/datacite_metadata_schema_org_request.js");
+        // DATASHARE - end
+
         // Add persistent identifiers
         /* Temporarily switch to using metadata directly.
          * FIXME Proper fix is to have IdentifierService handle all durable


### PR DESCRIPTION
…based on reference in https://support.datacite.org/docs/how-do-i-expose-my-datasets-to-google-dataset-search and https://gist.github.com/kjgarza/34ca6a866b4437bc1c07d84f208a01c4

Added a javascript file to the landing page (item view page) that creates schema.org markup to facilitate Google Dataset searches.

Unfortunately, can only test it on Beta. As it requires items that have a DOI for testing.