### PR TITLE
IssueID #21478 - To debug why update of DOI metadata fails:

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DataCiteConnector.java
@@ -525,6 +525,19 @@ implements DOIConnector
         }
         else if (!metadataDOI.equals(doi.substring(DOI.SCHEME.length())))
         {
+            // DATASHARE - start
+            // Code to display XML  when metadataDOI and doi.substring(DOI.SCHEME.length()) don't match
+            try {
+                log.info("metadataDOI: " + metadataDOI);
+                log.info("doi.substring(DOI.SCHEME.length()): " + doi.substring(DOI.SCHEME.length()));
+                Format format = Format.getCompactFormat();
+                format.setEncoding("UTF-8");
+                XMLOutputter xout = new XMLOutputter(format);
+                log.info("XML for when metadataDOI and DOI don't match:\n" + xout.outputString(root));
+            } catch(Exception e) {
+                log.info("Cannot display XML when metadataDOI and doi don't match " + e.toString());
+            }
+            // DATASHARE - end
             // FIXME: that's not an error. If at all, it is worth logging it.
             throw new DOIIdentifierException("DSO with type " + dso.getTypeText()
                     + " and id " + dso.getID() + " already has DOI "


### PR DESCRIPTION
  - Added code to display metadataDOI, doi and XML when attempting to update fails. We know that the case is that the metadataDOI string displays a truncated DOI string, e.g, metadataDOI = ".7488/ds/295" instead of "10.7488/ds/295".