### PR TITLE
IssueID #21844 - Adding Altmetric badge to landing page.

### DIFF
--- a/dspace-xmlui/src/main/webapp/static/js/altmetric-badge.js
+++ b/dspace-xmlui/src/main/webapp/static/js/altmetric-badge.js
@@ -1,0 +1,8 @@
+// DATASHARE - start
+$(document).ready(function () {
+	$('#altimetric-badge-title').hide();
+	$('div.altmetric-embed').on('altmetric:show', function () {
+		$('#altimetric-badge-title').show();
+	});
+});
+// DATASHARE - end

--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/xsl/aspect/artifactbrowser/item-view.xsl
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/xsl/aspect/artifactbrowser/item-view.xsl
@@ -134,6 +134,8 @@
                     <xsl:if test="$ds_item_view_toggle_url != ''">
                         <xsl:call-template name="itemSummaryView-show-full"/>
                     </xsl:if>
+
+                    <xsl:call-template name="itemSummaryView-altmetric-badge"/>
                 </div>
                 <div class="col-sm-8">
                   <xsl:call-template name="itemSummaryView-DIM-citation"/>
@@ -971,6 +973,26 @@
         <!--Lookup the MIME Type's key in messages.xml language file.  If not found, just display MIME Type-->
         <i18n:text i18n:key="{$mimetype-key}"><xsl:value-of select="$mimetype"/></i18n:text>
     </xsl:template>
+
+    <!-- DATASHARE - start -->
+    <xsl:template name="itemSummaryView-altmetric-badge">
+        <xsl:for-each select="dim:field[@element='identifier' and @qualifier='uri']">
+            <xsl:variable name="doi" select="./node()"></xsl:variable>
+            <xsl:if test="starts-with($doi, 'https://doi.org/')">
+               <h5 id="altimetric-badge-title">Altmetric</h5>
+               <div data-badge-popover="right"
+                    data-badge-type="donut"
+                    data-condensed="true"
+                    data-hide-no-mentions="true"
+                    class="altmetric-embed">
+                    <xsl:attribute name="data-doi"><xsl:value-of select="substring($doi,17)"/></xsl:attribute>
+               </div>
+               <br/>
+               <script type='text/javascript' src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js'></script>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+    <!-- DATASHARE - end -->
 
 
 </xsl:stylesheet>

--- a/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
+++ b/dspace/modules/xmlui/src/main/java/org/dspace/app/xmlui/aspect/artifactbrowser/ItemViewer.java
@@ -221,6 +221,7 @@ public class ItemViewer extends AbstractDSpaceTransformer implements CacheablePr
         
         // DATASHARE - start
         pageMeta.addMetadata("javascript", "static").addContent("static/js/datacite_metadata_schema_org_request.js");
+        pageMeta.addMetadata("javascript", "static").addContent("static/js/altmetric-badge.js");
         // DATASHARE - end
 	
 	// Add persistent identifiers


### PR DESCRIPTION
    We only add a badge div and script to the page if the item has a DOI.
    Also the badge is configured to ensure it will only be visible if Altmetric data exists for the DOI.

Examples of Altmetric badge when data present.

![Selection_050](https://user-images.githubusercontent.com/8876215/61220406-2a259e80-a70e-11e9-8ff7-b50480ee48e1.png)
![Selection_052](https://user-images.githubusercontent.com/8876215/61220439-3f023200-a70e-11e9-81c7-416020fbde4a.png)
![Selection_053](https://user-images.githubusercontent.com/8876215/61220456-47f30380-a70e-11e9-94a0-8afecc573b04.png)

